### PR TITLE
feat: add Mistral provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Vibe Architect is an open-source tool that helps you turn a raw app idea into a 
 
 - **Guided brainstorming** — The AI proposes concrete options (not open-ended questions) through a Propose → Refine → Lock workflow
 - **Live design previews** — See your design system rendered in real-time as the AI generates React component previews
-- **Multi-model support** — Bring your own API key for OpenAI (GPT-5.2), Google (Gemini 3), or Anthropic (Claude Opus/Sonnet)
+- **Multi-model support** — Bring your own API key for OpenAI (GPT-5.2), Google (Gemini 3), Anthropic (Claude Opus/Sonnet), or Mistral (Medium/Small)
 - **Voice input** — Speak your ideas using the built-in mic button (Whisper-powered transcription)
 - **Spec editor** — Edit generated specs directly in the built-in markdown editor
 - **Export** — Download your complete spec as markdown files, ready for your coding workflow
@@ -82,6 +82,7 @@ Click the **⚙️ Settings** icon in the app and add your API key(s):
 | OpenAI | GPT-5.2 (High / Medium / XHigh) |
 | Google | Gemini 3 Pro, Gemini 3 Flash |
 | Anthropic | Claude Opus 4.6, Claude Sonnet 4.5 |
+| Mistral | Mistral Medium 3.1, Mistral Small 3.2 |
 
 Keys are stored locally in your browser — they never leave your machine.
 
@@ -94,6 +95,8 @@ Keys are stored locally in your browser — they never leave your machine.
 | Gemini 3 Flash | Google | 65,536 |
 | Claude Opus 4.6 | Anthropic | 128,000 |
 | Claude Sonnet 4.5 | Anthropic | 64,000 |
+| Mistral Medium 3.1 | Mistral | 8,192 |
+| Mistral Small 3.2 | Mistral | 8,192 |
 
 ## Tech Stack
 

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -16,6 +16,7 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         openai: s.openaiKey,
         gemini: s.geminiKey,
         anthropic: s.anthropicKey,
+        mistral: s.mistralKey,
     });
     const [showKeys, setShowKeys] = useState(false);
 
@@ -24,8 +25,9 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
             openai: s.openaiKey,
             gemini: s.geminiKey,
             anthropic: s.anthropicKey,
+            mistral: s.mistralKey,
         });
-    }, [s.openaiKey, s.geminiKey, s.anthropicKey, isOpen]);
+    }, [s.openaiKey, s.geminiKey, s.anthropicKey, s.mistralKey, isOpen]);
 
     if (!isOpen) return null;
 
@@ -33,12 +35,13 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         s.setKey("openai", keys.openai.trim());
         s.setKey("gemini", keys.gemini.trim());
         s.setKey("anthropic", keys.anthropic.trim());
+        s.setKey("mistral", keys.mistral.trim());
         onClose();
     };
 
     const handleClear = () => {
         s.clearKeys();
-        setKeys({ openai: "", gemini: "", anthropic: "" });
+        setKeys({ openai: "", gemini: "", anthropic: "", mistral: "" });
     };
 
     return (
@@ -88,6 +91,14 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                         show={showKeys}
                         configured={s.anthropicKey.length > 0}
                     />
+                    <KeyInput
+                        label="Mistral"
+                        value={keys.mistral}
+                        onChange={(v) => setKeys({ ...keys, mistral: v })}
+                        placeholder="your-mistral-key"
+                        show={showKeys}
+                        configured={s.mistralKey.length > 0}
+                    />
                     <button
                         onClick={() => setShowKeys(!showKeys)}
                         className="mt-1 text-xs text-[var(--accent-dim)] transition-colors hover:text-[var(--accent-muted)]"
@@ -104,7 +115,8 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 m.provider === "openai" ? keys.openai.trim().length > 0
                                     : m.provider === "gemini" ? keys.gemini.trim().length > 0
                                         : m.provider === "anthropic" ? keys.anthropic.trim().length > 0
-                                            : false;
+                                            : m.provider === "mistral" ? keys.mistral.trim().length > 0
+                                                : false;
                             return (
                                 <button
                                     key={m.id}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export interface Message {
 
 
 // LLM providers for text chat and the ASR+TTS pipeline
-export type LLMProvider = "openai" | "gemini" | "anthropic";
+export type LLMProvider = "openai" | "gemini" | "anthropic" | "mistral";
 
 // Specific models
 export type LLMModel =
@@ -40,7 +40,9 @@ export type LLMModel =
   | "gemini-3-pro"
   | "gemini-3-flash"
   | "claude-opus-4.6"
-  | "claude-sonnet-4.5";
+  | "claude-sonnet-4.5"
+  | "mistral-medium-3.1"
+  | "mistral-small-3.2";
 
 export interface LLMModelConfig {
   id: LLMModel;
@@ -105,6 +107,20 @@ export const LLM_MODELS: LLMModelConfig[] = [
     provider: "anthropic",
     maxTokens: 64000,
     apiModel: "claude-sonnet-4-5-20250929",
+  },
+  {
+    id: "mistral-medium-3.1",
+    name: "Mistral Medium 3.1",
+    provider: "mistral",
+    maxTokens: 8192,
+    apiModel: "mistral-medium-latest",
+  },
+  {
+    id: "mistral-small-3.2",
+    name: "Mistral Small 3.2",
+    provider: "mistral",
+    maxTokens: 8192,
+    apiModel: "mistral-small-latest",
   },
 ];
 


### PR DESCRIPTION
## Summary
- add Mistral as a first-class LLM provider
- add Mistral model options to the model registry
- add persistent Mistral API key support in settings store
- add Mistral API key input and model gating in settings modal
- add streaming support via Mistral chat completions API
- update README provider/model tables

## Validation
- npx tsc --noEmit
- npm run lint (fails due to pre-existing lint issues unrelated to this feature)